### PR TITLE
[PD-4296] update branch from main to master

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -3,7 +3,7 @@
     "title": "Velocity",
     "author": "PathFactory",
     "version": "0.1.2",
-    "url": "https://github.com/buzzdata/velocity-theme/archive/refs/heads/main.zip",
+    "url": "https://github.com/buzzdata/velocity-theme/archive/refs/heads/master.zip",
     "thumbnail": "https://raw.githubusercontent.com/buzzdata/themes/main/images/PathFactory_Logo_RGB_Icon_Color.png"
   }
 ]


### PR DESCRIPTION
The themes repository is referred to in revenue-enablement repo within file src/Shared/FormFields/ThemePresetPicker.tsx. It tells revenue-enablement which branch to use when creating new themes from velocity-theme repo.

The themes repository's purpose is to keep track of the versions of velocity-theme repo, although it is not presently being used in this capacity (currently it just returns a single version in the payload).

The purpose of this ticket is to change the branch of the velocity-theme repo that we are pulling from. Before, we pull from main branch. Now, we pull from master branch.

There is one complicating factor. The revenue-enablement file currently only pulls the velocity-theme information from the main branch of themes repo for all environments, which means if I merge the changes to themes main branch, it will immediately affect production.

Therefore, changes have been made to revenue-enablement side in this PR https://github.com/buzzdata/revenue-enablement/pull/473. Now, it will pull from develop branch of themes repo if non-prod environment, and it will pull from master branch if production environment.

For themes repo, I will merge changes to the develop branch, and then develop will merge to master on release day. This way, when I merge my changes to themes repo, it will not immediately impact production.


