### PR TITLE
[PD-7062] update development to 1.2

### DIFF
--- a/development_themes.json
+++ b/development_themes.json
@@ -1,9 +1,9 @@
 [
     {
-        "title": "Development - Velocity 1.1",
+        "title": "Development - Velocity 1.2",
         "author": "PathFactory devs",
-        "version": "1.1",
-        "url": "https://github.com/buzzdata/velocity-theme/archive/refs/heads/v1.1.zip",
+        "version": "1.2",
+        "url": "https://github.com/buzzdata/velocity-theme/archive/refs/heads/v1.2.zip",
         "thumbnail": "https://raw.githubusercontent.com/buzzdata/themes/develop/images/PathFactory_Logo_RGB_Icon_Color.png"
     },
     {


### PR DESCRIPTION
For non-prod env only, need to switch v1.1 to v1.2
When epic is released to prod, prod goes straight to v2.0 - will have separate PR for that when day comes